### PR TITLE
Began restructuring tests; Fixed Curve path resolution error between systems

### DIFF
--- a/Curve/curve.py
+++ b/Curve/curve.py
@@ -157,7 +157,8 @@ class Curve:
         assert end > 0
 
         from pathlib import Path
-        with open(Path(__file__).parent.as_posix() + r"\regex", 'r') as regex:
+        from os.path import join
+        with open(join(Path(__file__).parent.as_posix(), r"regex"), 'r') as regex:
             tokenRegex = re.compile(regex.readline())
 
         terms: list = [term.strip() for term in curve.split("+")]

--- a/Curve/test/test.py
+++ b/Curve/test/test.py
@@ -1,7 +1,0 @@
-from pytest import raises
-from Curve.curve import Curve
-
-
-def test_init():
-    with raises(Exception):
-        Curve([-1, 0, 0, 3, 1e10]).checkValidity()

--- a/test_out.txt
+++ b/test_out.txt
@@ -1,38 +1,39 @@
-================================================= test session starts =================================================
-platform win32 -- Python 3.8.2, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- c:\users\azor ahai\documents\py\zappy-jb\venv\scripts\python.exe
+=========================================================================== test session starts ============================================================================
+platform linux -- Python 3.6.9, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /mnt/c/users/azor ahai/documents/py/zappy-JB/venvwsl/bin/python
 cachedir: .pytest_cache
-rootdir: C:\Users\Azor Ahai\Documents\Py\zappy-JB
-plugins: session2file-0.1.11, web3-5.16.0
+rootdir: /mnt/c/users/azor ahai/documents/py/zappy-JB
+plugins: session2file-0.1.11, web3-5.17.0
 collecting ... 
-collected 28 items                                                                                                     
+collecting 28 items                                                                                                                                                        
+collected 28 items                                                                                                                                                         
 
-Curve/test/Curve_test.py::test_init PASSED                                                                       [  3%]
-Curve/test/Curve_test.py::test_getPrice_invalid[-1-curve0] PASSED                                                [  7%]
-Curve/test/Curve_test.py::test_getPrice_invalid[100000000000.0-curve1] PASSED                                    [ 10%]
-Curve/test/Curve_test.py::test_getPrice_valid[1-expected0] PASSED                                                [ 14%]
-Curve/test/Curve_test.py::test_getPrice_valid[10-expected1] PASSED                                               [ 17%]
-Curve/test/Curve_test.py::test_getPrice_valid[1000000000.0-expected2] PASSED                                     [ 21%]
-Curve/test/Curve_test.py::test_getZapRequired_invalid[-1-1-Invalid curve supply position] PASSED                 [ 25%]
-Curve/test/Curve_test.py::test_getZapRequired_invalid[100000000000.0-1-Invalid curve supply position] PASSED     [ 28%]
-Curve/test/Curve_test.py::test_getZapRequired_invalid[1-100000000000.0-None] PASSED                              [ 32%]
-Curve/test/Curve_test.py::test_getZapRequired_valid[2-3] PASSED                                                  [ 35%]
-Curve/test/Curve_test.py::test_getZapRequired_valid[1-5] PASSED                                                  [ 39%]
-Curve/test/Curve_test.py::test_getZapRequired_valid[1-10] PASSED                                                 [ 42%]
-Curve/test/Curve_test.py::test_getZapRequired_valid[5-1000.0] PASSED                                             [ 46%]
-Curve/test/Curve_test.py::test_valuesToString PASSED                                                             [ 50%]
-Curve/test/Curve_test.py::test_splitCurveToTerms PASSED                                                          [ 53%]
-Curve/test/Curve_test.py::test_termToString PASSED                                                               [ 57%]
-Curve/test/Curve_test.py::test_curveToString PASSED                                                              [ 60%]
-Curve/test/Curve_test.py::test_convertToCurve_invalid[4x^2+6x^7-hi-Start and end must be numbers] PASSED         [ 64%]
-Curve/test/Curve_test.py::test_convertToCurve_invalid[4x^2+6x^7-1e10-Start and end must be numbers] PASSED       [ 67%]
-Curve/test/Curve_test.py::test_convertToCurve_invalid[4x^2+6x^7-None-Start and end must be numbers] PASSED       [ 71%]
-Curve/test/Curve_test.py::test_convertToCurve_invalid_assert[4x^2+6x^7--1] PASSED                                [ 75%]
-Curve/test/Curve_test.py::test_convertToCurve_invalid_assert[4x^2+6x^7--10000] PASSED                            [ 78%]
-Curve/test/Curve_test.py::test_convertToCurve[3x^2-10000000000.0-expected_curve0] PASSED                         [ 82%]
-Curve/test/Curve_test.py::test_convertToCurve[x^0+3x^2-10000000000.0-expected_curve1] PASSED                     [ 85%]
-Curve/test/Curve_test.py::test_convertToCurve[4x^0+2x^1+3x^2-100000000.0-expected_curve2] PASSED                 [ 89%]
-Curve/test/Curve_test.py::test_convertToCurve[4x^0+2tetherx^1+3x^2-100000000.0-expected_curve3] PASSED           [ 92%]
-Curve/test/Curve_test.py::test_convertToCurve[x^0+0.00001x^2-1000000.0-expected_curve4] PASSED                   [ 96%]
-Curve/test/Curve_test.py::test_convertToCurve[x^0+100000.0szabox^2-1000000.0-expected_curve5] PASSED             [100%]
+tests/Curve/test_curve.py::test_init PASSED                                                                                                                          [  3%]
+tests/Curve/test_curve.py::test_getPrice_invalid[-1-curve0] PASSED                                                                                                   [  7%]
+tests/Curve/test_curve.py::test_getPrice_invalid[100000000000.0-curve1] PASSED                                                                                       [ 10%]
+tests/Curve/test_curve.py::test_getPrice_valid[1-expected0] PASSED                                                                                                   [ 14%]
+tests/Curve/test_curve.py::test_getPrice_valid[10-expected1] PASSED                                                                                                  [ 17%]
+tests/Curve/test_curve.py::test_getPrice_valid[1000000000.0-expected2] PASSED                                                                                        [ 21%]
+tests/Curve/test_curve.py::test_getZapRequired_invalid[-1-1-Invalid curve supply position] PASSED                                                                    [ 25%]
+tests/Curve/test_curve.py::test_getZapRequired_invalid[100000000000.0-1-Invalid curve supply position] PASSED                                                        [ 28%]
+tests/Curve/test_curve.py::test_getZapRequired_invalid[1-100000000000.0-None] PASSED                                                                                 [ 32%]
+tests/Curve/test_curve.py::test_getZapRequired_valid[2-3] PASSED                                                                                                     [ 35%]
+tests/Curve/test_curve.py::test_getZapRequired_valid[1-5] PASSED                                                                                                     [ 39%]
+tests/Curve/test_curve.py::test_getZapRequired_valid[1-10] PASSED                                                                                                    [ 42%]
+tests/Curve/test_curve.py::test_getZapRequired_valid[5-1000.0] PASSED                                                                                                [ 46%]
+tests/Curve/test_curve.py::test_valuesToString PASSED                                                                                                                [ 50%]
+tests/Curve/test_curve.py::test_splitCurveToTerms PASSED                                                                                                             [ 53%]
+tests/Curve/test_curve.py::test_termToString PASSED                                                                                                                  [ 57%]
+tests/Curve/test_curve.py::test_curveToString PASSED                                                                                                                 [ 60%]
+tests/Curve/test_curve.py::test_convertToCurve_invalid[4x^2+6x^7-hi-Start and end must be numbers] PASSED                                                            [ 64%]
+tests/Curve/test_curve.py::test_convertToCurve_invalid[4x^2+6x^7-1e10-Start and end must be numbers] PASSED                                                          [ 67%]
+tests/Curve/test_curve.py::test_convertToCurve_invalid[4x^2+6x^7-None-Start and end must be numbers] PASSED                                                          [ 71%]
+tests/Curve/test_curve.py::test_convertToCurve_invalid_assert[4x^2+6x^7--1] PASSED                                                                                   [ 75%]
+tests/Curve/test_curve.py::test_convertToCurve_invalid_assert[4x^2+6x^7--10000] PASSED                                                                               [ 78%]
+tests/Curve/test_curve.py::test_convertToCurve[3x^2-10000000000.0-expected_curve0] PASSED                                                                            [ 82%]
+tests/Curve/test_curve.py::test_convertToCurve[x^0+3x^2-10000000000.0-expected_curve1] PASSED                                                                        [ 85%]
+tests/Curve/test_curve.py::test_convertToCurve[4x^0+2x^1+3x^2-100000000.0-expected_curve2] PASSED                                                                    [ 89%]
+tests/Curve/test_curve.py::test_convertToCurve[4x^0+2tetherx^1+3x^2-100000000.0-expected_curve3] PASSED                                                              [ 92%]
+tests/Curve/test_curve.py::test_convertToCurve[x^0+0.00001x^2-1000000.0-expected_curve4] PASSED                                                                      [ 96%]
+tests/Curve/test_curve.py::test_convertToCurve[x^0+100000.0szabox^2-1000000.0-expected_curve5] PASSED                                                                [100%]
 
-================================================= [32m[1m28 passed[0m[32m in 0.29s[0m[32m ==================================================
+============================================================================ [32m[1m28 passed[0m[32m in 1.68s[0m[32m ============================================================================

--- a/tests/Curve/test_curve.py
+++ b/tests/Curve/test_curve.py
@@ -1,11 +1,16 @@
 from pytest import raises, fixture, mark, approx
+from os.path import join, realpath
+import sys
+sys.path.pop(0)
+sys.path.insert(0, realpath(join(__file__, "../../../")))
+print(sys.path)
 from Curve.curve import Curve, isWhole
 """
     Get a detailed test output and upload to a pastebin:
-        pytest -r p --pastebin=all
+        pytest -v -r p --pastebin=all
 
     Show fixtures used for test
-        pytest -r p --fixtures-per-test
+        pytest -v -r p --fixtures-per-test
 """
 
 

--- a/tests/Curve/test_curve.py
+++ b/tests/Curve/test_curve.py
@@ -1,9 +1,7 @@
 from pytest import raises, fixture, mark, approx
 from os.path import join, realpath
 import sys
-sys.path.pop(0)
 sys.path.insert(0, realpath(join(__file__, "../../../")))
-print(sys.path)
 from Curve.curve import Curve, isWhole
 """
     Get a detailed test output and upload to a pastebin:


### PR DESCRIPTION
## Summary
Tests now follow the first layout explained in [this document](https://docs.pytest.org/en/reorganize-docs/new-docs/user/directory_structure.html). Fixed path resolution error between windows and unix systems.

## Files
```Curve/curve.py
Curve/curve.py
tests/__init__.py
tests/Curve/test_curve.py
test_out.txt
```

## Visual Preview
Test output
![](https://i.ibb.co/xHJdygJ/image.png)
[local file with test output](https://github.com/zapproject/zappy/blob/develop/test_out.txt)

## Future
* More tests being placed within `tests` directory
